### PR TITLE
terraform apply時に`desired_vcpus = 0`にしようとしてしまう問題の解消

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -188,6 +188,11 @@ resource "aws_batch_compute_environment" "this" {
   depends_on = [
     "aws_iam_role_policy_attachment.aws_batch_service_role",
   ]
+  lifecycle {
+    ignore_changes = [
+      "compute_resources.0.desired_vcpus",
+    ]
+  }
 }
 
 resource "aws_batch_job_queue" "this" {


### PR DESCRIPTION
参考にさせていただいて、構築した時に気になった点でしたのでPRとして上げさせていただきました。